### PR TITLE
chore: drop changes-branch:next from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,3 @@ jobs:
       - uses: Increase/release-please@v1
         with:
           token: ${{ steps.app-token.outputs.token }}
-          changes-branch: next


### PR DESCRIPTION
## Summary

The original release-please cutover ([#1361](https://github.com/Increase/increase-typescript/pull/1361)) prescribed \`changes-branch: next\` to mirror Stainless's prior topology where SDK codegen landed on a \`next\` staging branch. We're retiring that convention in favour of landing codegen directly on \`main\` via [\`Increase/stainless\`](https://github.com/bnk-dev/stainless)'s \`tools/promote/\` harness — same fix applied to \`Increase/increase-go\` during the v0.591.0 -> v0.592.0 recovery ([Increase/increase-go#1279](https://github.com/Increase/increase-go/pull/1279)).

With \`changes-branch: next\` left in place, the workflow runs but release-please scans \`next\` (which is exactly at \`release: 0.568.0\`, behind \`main\` by the cutover commit) and finds no commits to release. Dropping the input lets the action use its default (the workflow ref, i.e. \`main\`), so subsequent \`feat(api)\` / \`fix(...)\` commits open a release PR as expected.

## What this enables

After merge:

1. The \`release\` workflow re-runs against \`main\`.
2. release-please finds the cutover commit (\`chore: add release workflow ...\`) since the last \`release: 0.568.0\` tag.
3. A release PR opens against \`release-please--branches--main--components--increase\` (the component branch derived from \`package.json\`'s \`"name": "increase"\`).
4. Merging that release PR creates the tag + GitHub Release and fires the existing \`publish-npm.yml\` workflow.

## Follow-up

- After this lands, delete the \`next\` branch — nothing is stranded on it (\`gh api repos/.../compare/main...next\` returns \`status: behind, ahead_by: 0\`).