### PR TITLE
ci: restore release-please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.INCREASE_RELEASES_CLIENT_ID }}
+          private-key: ${{ secrets.INCREASE_RELEASES_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Increase/release-please@a9c58f256d7c7443d63d4b42d16f9ee6a04616e2 # v1.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
`.github/workflows/release.yml` was deleted by sync PR #1406 (merged earlier today), which silently disabled release automation for this repo — no Release PR is opened on pushes to `main`.

This restores the standard `Increase/release-please` workflow, byte-identical to the version in all other Increase SDK repos (e.g. increase-go) and to the version present here through v0.575.0.

Stopgap: the generator should also be fixed so `release.yml` is emitted for increase-typescript and not dropped by future syncs.